### PR TITLE
install futures python 2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 termcolor
+futures


### PR DESCRIPTION
python 2.7 is not install futures as default like python 3